### PR TITLE
Feature Handling signals

### DIFF
--- a/saijdsad
+++ b/saijdsad
@@ -1,2 +1,0 @@
-DEBUG: First command - stdin from terminal
-DEBUG: Command 0 - stdout to pipe[0][1]

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ static void	run_shell(t_shell *mshell, t_token **token, char **envp)
 	modify_shell_level(mshell->env_list, 1);
 	while (mshell->is_running)
 	{
-		handle_signal(mshell);
+		handle_signal();
 		init_shell_envp_cwd(mshell, envp);
 		mshell->rd_l = readline(mshell->fake_cwd);
 		if (mshell->rd_l && mshell->rd_l[0])
@@ -24,17 +24,17 @@ static void	run_shell(t_shell *mshell, t_token **token, char **envp)
 		if (!mshell->rd_l)
 		{
 			handle_error_shell(mshell, token);
-			exit (1);
+			exit (0);
 		}
 		if (!mshell->rd_l[0] || !parsing(mshell, token))
 		{
 			free_all(mshell, token);
 			continue ;
 		}
+		if (g_sig == 130)
+			mshell->exit_code = 130;
 		execute_cmd_line(mshell, token);
 		free_all(mshell, token);
-		if (g_sig == SIGINT)
-			mshell->exit_code = g_sig;
 		ft_printf("%d\n",mshell->exit_code);
 		g_sig = 0;
 	}

--- a/src/signals.c
+++ b/src/signals.c
@@ -35,5 +35,5 @@ void	handle_ctrl_c_child(int sig)
 void	handle_signal(void)
 {
 	signal(SIGINT, handle_ctrl_c);
-	//signal(SIGQUIT, SIG_IGN);
+	signal(SIGQUIT, SIG_IGN);
 }


### PR DESCRIPTION
-  SIGINT now is properly handle and updated so that when pressed returns 130 and global variable reset to zero
- CTRL+D now return zero (might need to check that) but from what I saw bash did not return an error when CTRL+D was pressed, just quit the shell
- SIGQUIT now is properly ignored and doesn't core dump when signal is given (still needs to be tested but seems alright)