### PR TITLE
Feature: File permission checker

### DIFF
--- a/TESTES.txt
+++ b/TESTES.txt
@@ -6,15 +6,18 @@
 # Test 1: Basic echo redirect
 echo "hello world" > output.txt
 cat output.txt
+(WORKS)
 
 # Test 2: Overwrite existing file
 echo "first content" > test.txt
 echo "second content" > test.txt
 cat test.txt
+(WORKS)
 
 # Test 3: Redirect command output
 pwd > current_dir.txt
 cat current_dir.txt
+(WORKS)
 
 # Test 4: Redirect with built-ins
 env > environment.txt

--- a/includes/parsing.h
+++ b/includes/parsing.h
@@ -20,5 +20,6 @@ int		quote_checker(char *rd_l);
 int		check_pipeline(t_token **token);
 int		check_redir_type(t_token *temp);
 int		check_infile(t_token *token);
+int		check_perms(t_shell *mshell, t_token *token);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -23,8 +23,11 @@ static void	run_shell(t_shell *mshell, t_token **token, char **envp)
 			add_history(mshell->rd_l);
 		if (!mshell->rd_l)
 		{
+			if (g_sig == 130)
+				mshell->exit_code = 130;
+			ft_printf("exit\n");
 			handle_error_shell(mshell, token);
-			exit (0);
+			exit(mshell->exit_code);
 		}
 		if (!mshell->rd_l[0] || !parsing(mshell, token))
 		{


### PR DESCRIPTION
-Added a checker to see if files have permissions before trying to execute them, because it was leaking a lot when it went through and opened them to check for the permissions. Now behaves more like bash. 
-Started working on the tests and started giving notations when needed. 
-Might be relevant to check if the directory we are trying to create files in has write permissions; otherwise, there might be some errors